### PR TITLE
Is failing silently when you have file errors like broken links.

### DIFF
--- a/build/templates.js
+++ b/build/templates.js
@@ -100,7 +100,15 @@ module.exports = {
 			// get the list of templates
 			function(mtime, callback) {
 				settings._utils.find(path, new RegExp(/template.html/), function(err, matches) {
-					
+					if(err) {
+						throw err;
+					}
+
+					if(!matches) {
+						callback(null);
+						return;
+					}
+
 					// now loop over each file and compare its mtime to the previously generated mtime
 					async.map([indexHtml].concat(matches), fs.stat, function(err, results) {
 						


### PR DESCRIPTION
It's failing without a correct error reporting, this is just returning the correct error message to the user.

In this case is an error reading a specific file:

<img width="670" alt="screen shot 2015-08-12 at 5 22 35 pm" src="https://cloud.githubusercontent.com/assets/272756/9238317/06120daa-4117-11e5-9dd4-789e9d70bbaf.png">
